### PR TITLE
Change capitalization on suggested PR title

### DIFF
--- a/responses/13_action-three-workflow.md
+++ b/responses/13_action-three-workflow.md
@@ -63,7 +63,7 @@ We need to make some edits to the `my-workflow.yml` file to get it configured to
    ```
 
 1. Commit the changes to a new branch and name it `action-three`.
-1. Create a pull request named **Use Outputs**
+1. Create a pull request named **Use outputs**
 
 
 ---


### PR DESCRIPTION
This PR updates the response body where we tell the user how to name their pull request. It is a case sensitive request, and we provide the wrong version in this instruction.

_Note: I also saw some talk in chat a while ago about possibly removing these gates and I am in full support of that 🙃 _