### PR TITLE
Fix: Cat facts API no longer available

### DIFF
--- a/responses/10_create-python-file.md
+++ b/responses/10_create-python-file.md
@@ -2,34 +2,41 @@
 
 **Cat Fact API**
 
-We will be using the [cat-fact API](https://cat-fact.herokuapp.com/facts) for our action. This API does not require any authentication making it an ideal teaching tool.
+We will be using the [Cat Facts API](https://catfact.ninja/facts) for our action. This API does not require any authentication making it an ideal teaching tool.
 
-When we make our request to this API we will get back an array JSON Objects in the response. An individual Object looks like this:
+When we make our request to this API we will get back a JSON Object in the response. An outline of the Object will looks like this:
 
 ```json
 {
-  "_id": "58e008ad0aac31001185ed0c",
-  "text": "The frequency of a domestic cat;s purr is the same at which muscles and bones repair themselves.",
-  "type": "cat",
-  "user": {
-    "_id": "58e007480aac31001185ecef",
-    "name": {
-      "first": "Kasimir",
-      "last": "Schulz"
+  "current_page": 1,
+  "data": [
+    {
+      "fact": "The Egyptian Mau is probably the oldest breed of cat. In fact, the breed is so ancient that its name is the Egyptian word for “cat.”",
+      "length": 132
     }
-  },
-  "upvotes": 6,
-  "userUpvoted": "None"
+  ],
+  "first_page_url": "https://catfact.ninja/facts?page=1",
+  "from": 1,
+  "last_page": 332,
+  "last_page_url": "https://catfact.ninja/facts?page=332",
+  "next_page_url": "https://catfact.ninja/facts?page=2",
+  "path": "https://catfact.ninja/facts",
+  "per_page": 1,
+  "prev_page_url": null,
+  "to": 1,
+  "total": 332
 }
 ```
 
-It contains many **key:value** pairs of data that we can use in our own program or service. In our case, we are only interested in the `text` field.
+It contains an Object of data that we can use in our own program or service. In our case, we are only interested in the `data` field.
 
-Our action will extract the `text` field in a new array, then select a random index to display in the console as our random cat fact.
+Our action will extract the `data` field in a new array, then select a random index to display in the console as our random cat fact.
 
 To further demonstrate the flexibility of Docker actions we will create this one using Python.
 
 If Python is a new programming language to you, like always don't worry. You are here to learn about actions and we will supply all the necessary source code for you.
+
+To get more results from the Cat Fact API we will append the `limit` query parameter to the end of the endpoint.
 
 ### :keyboard: Activity: Create the Python source code for the cat-fats action
 
@@ -41,18 +48,18 @@ If Python is a new programming language to you, like always don't worry. You are
    import random
    import sys
 
-   # Make an HTTP GET request to the cat-fact API
-   cat_url = "https://cat-fact.herokuapp.com/facts"
+   # Make an HTTP GET request to the Cat Fact API
+   cat_url = "https://catfact.ninja/facts?limit=50"
    r = requests.get(cat_url)
-   r_obj_list = r.json()["all"]
+   r_obj_list = r.json()["data"] 
 
    # Create an empty list to store individual facts in
    # This will make it easy to select a random one later
    fact_list = []
 
-   # Add the "text" of every object into the fact_list list
+   # Add the "fact" of every object into the fact_list list
    for fact in r_obj_list:
-       fact_list.append(fact["text"])
+       fact_list.append(fact["fact"])
 
    # Select a random fact from the fact_list and return it
    # into a variable named random_fact so we can use it


### PR DESCRIPTION
Hello there. 👋

## Related issues.

I had this issue before and notified staff on the forums about this issue. Saw the issue (#9) was still open and had been marked for Hacktoberfest. So here's the solution I came up with to fixed the issue.

## Suggested solution.

I changed the API to the [catfact.ninja] and updated the wording on the response to match it. The `main.py` has been modified for the new API and returns a similar result set from the old API, just with a different key, `text` to `fact`.
But since the `::set-output` doesn't change and just returns a string, the other responses don't have to change as well.

## Any tests?

No, I tried to create a new course based on the fork but it won't let me. It just keeps loading so I'm now 100% on how to actually test this. 😕

[catfact.ninja]:https://catfact.ninja/