### PR TITLE
force specific golang version in dockerfile

### DIFF
--- a/responses/07_create-dockerfile.md
+++ b/responses/07_create-dockerfile.md
@@ -16,7 +16,7 @@ Lastly we will create the `Dockerfile`. Like with Go programming, it is perfectl
    You can use [this link]({{quicklink}}) to easily create this file in the proper location.
 
    ```dockerfile
-   FROM golang:latest
+   FROM golang:1.15
    WORKDIR /go/src/hello
    COPY . .
    RUN go get -d -v ./...


### PR DESCRIPTION
The current Dockerfile we ask the user to write pulls in the latest version of Go which treats modules differently from the version the exercise was written with.

To remedy this breakage we can force the version of Go used by changing the tag in the Dockerfile.  This fix should allow the learner to continue through the lab without any issues.